### PR TITLE
fix: made text static, simplified template config.json

### DIFF
--- a/assets/app-preact/config.json
+++ b/assets/app-preact/config.json
@@ -25,12 +25,10 @@
   },
   "commands": {
     "install": {
-      "exec": "npm install --silent --save preact preact-compat preact-emotion preact-router emotion@9.2.12 > /dev/null",
-      "output": " \u001b[1m\u001b[37mcreate-pika-app\u001b[22m\u001b[39m installing... \u001b[36mpreact\u001b[39m, \u001b[36mpreact-compat\u001b[39m, \u001b[36memotion\u001b[39m, \u001b[36mpreact-emotion\u001b[39m, and \u001b[36mpreact-router\u001b[39m"
+      "exec": "npm install --silent --save preact preact-compat preact-emotion preact-router emotion@9.2.12 > /dev/null"
     },
     "install -D": {
-      "exec": "npm install --silent -D @babel/cli @babel/core @babel/plugin-proposal-class-properties @babel/plugin-proposal-object-rest-spread @babel/plugin-transform-react-jsx @babel/preset-env @babel/preset-react @babel/preset-typescript @pika/web@0.4.2 @typescript-eslint/eslint-plugin @typescript-eslint/parser babel-plugin-import-pika-web babel-plugin-module-resolver concurrently copyfiles prettier eslint eslint-config-airbnb-typescript eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react serve typescript > /dev/null",
-      "output": " \u001b[1m\u001b[37mcreate-pika-app\u001b[22m\u001b[39m installing... \u001b[36m@pika/web\u001b[39m, \u001b[36mtypescript\u001b[39m, \u001b[36meslint\u001b[39m, \u001b[36mserve\u001b[39m, \u001b[36mbabel\u001b[39m, and other dev dependencies"
+      "exec": "npm install --silent -D @babel/cli @babel/core @babel/plugin-proposal-class-properties @babel/plugin-proposal-object-rest-spread @babel/plugin-transform-react-jsx @babel/preset-env @babel/preset-react @babel/preset-typescript @pika/web@0.4.2 @typescript-eslint/eslint-plugin @typescript-eslint/parser babel-plugin-import-pika-web babel-plugin-module-resolver concurrently copyfiles prettier eslint eslint-config-airbnb-typescript eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react serve typescript > /dev/null"
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ const copyTemplates = (appDirectory, appTemplateLoc) => {
 const installDependencies = (appDirectory, appConfig) => {
   return new Promise(resolve => {
     const installDepSpinner = ora({
-      text: appConfig.commands['install'].output,
+      text: ` ${bold().white('create-pika-app')} installing dependencies...`
     }).start()
     shell.exec(
       `cd ${appDirectory} && ${appConfig.commands['install'].exec}`,
@@ -86,7 +86,7 @@ const installDependencies = (appDirectory, appConfig) => {
 const installDevDependencies = (appDirectory, appConfig) => {
   return new Promise(resolve => {
     const installDevDepSpinner = ora({
-      text: appConfig.commands['install -D'].output,
+      text: ` ${bold().white('create-pika-app')} installing dev dependencies...`
     }).start()
     shell.exec(
       `cd ${appDirectory} && ${appConfig.commands['install -D'].exec}`,


### PR DESCRIPTION
Removed the `output` property in the templates `config.json` in order to simplify creation of further templates, and replaced the text in the primary binary with a simple 'installing dependencies...' and 'installing dev dependencies...' messages.

What do you think? @FredKSchott 