### PR TITLE
chore: add readme & typo fix

### DIFF
--- a/assets/app-lit/template/README.md
+++ b/assets/app-lit/template/README.md
@@ -1,0 +1,52 @@
+# 🖥️ create-pika-app
+
+#### 🎉 `@Pika/Web` + `lit-html` + `lit-element` Example Project
+
+<img width="500px" src="https://i.imgur.com/f3oYQJS.png" align="right"></img>
+
+## 🚀 Getting Started
+
+```bash
+npm install
+npm start
+```
+
+It will then be available at `localhost:5000`
+
+## A note on directives
+
+If you want to use directives, you'll have to add them to the `webDependencies` property in your `package.json`:
+
+```json
+  "@pika/web": {
+    "webDependencies": [
+        "lit-html",
+        "lit-element",
+        "lit-html/directives/until.js",
+        "lit-html/directives/class-map.js"
+    ],
+  },
+```
+
+or
+
+```json
+  "@pika/web": {
+    "webDependencies": [
+        "lit-html",
+        "lit-element",
+        "lit-html/directives/"
+    ],
+  },
+```
+
+### 🙏 Special Thanks
+
+[@pika/web](https://github.com/pikapkg/web)  
+[lit-html](https://github.com/polymer/lit-html)
+[lit-element](https://github.com/polymer/lit-element)
+[create-pika-app](https://github.com/ndom91/create-pika-app)
+
+---
+
+📝 `License:` [`MIT`](https://opensource.org/licenses/MIT)

--- a/assets/app-lit/template/components/app-lit.js
+++ b/assets/app-lit/template/components/app-lit.js
@@ -5,13 +5,13 @@ import './todo-footer.js';
 export class AppLit extends LitElement {
     static get properties() {
         return {
-            todo: { type: Array }
+            todos: { type: Array }
         }
     }
 
     constructor() {
         super();
-        this.todo = [];
+        this.todos = [];
     }
     
     static get styles() {
@@ -41,14 +41,14 @@ export class AppLit extends LitElement {
     }
 
     addTodo() {
-        this.todo = [...this.todo, `Item ${this.todo.length}`];
+        this.todos = [...this.todos, `Item ${this.todos.length}`];
     }
 
     render() {
         return html`
             ${header("Todo list")}
             <ul>
-                ${this.todo.map(item => html`
+                ${this.todos.map(item => html`
                     <li>${item}</li>
                 `)}
             </ul>


### PR DESCRIPTION
- Small typo fix in the app-lit component (`todo` -> `todos`)
- And added a `README.md` with some extra notes on how to install and use lit-html directives :)