### PR TITLE
Remove unnecessary warning?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,9 +136,6 @@ export const run = async () => {
   }
 
   if (!program.template) {
-    console.log(
-      `No template chosen, please make a choice for ${cyan(appName)}\n`
-    )
     const output = []
     const templateDirectoryLoc = url.fileURLToPath(
       url.resolve(import.meta.url, `../assets`)


### PR DESCRIPTION
When I ran this on my machine for the first time, I was slightly confused by this "No template selected" message. Did I do something wrong? How could I have even selected a template (assuming I don't know about the CLI arg)?

<img width="473" alt="Screen Shot 2019-10-01 at 8 14 07 AM" src="https://user-images.githubusercontent.com/622227/65975793-ffe9a000-e423-11e9-91d2-804e387c3219.png">

If we remove that message, I don't think anything's lost for the user, and it is potentially less distracting. What do you think?

<img width="468" alt="Screen Shot 2019-10-01 at 8 16 21 AM" src="https://user-images.githubusercontent.com/622227/65975860-1e4f9b80-e424-11e9-8e7b-30cb0fd84416.png">
