### PR TITLE
fix: removed emotion from app-preact

### DIFF
--- a/assets/app-preact/config.json
+++ b/assets/app-preact/config.json
@@ -2,10 +2,8 @@
   "packageManifest": {
     "@pika/web": {
       "webDependencies": [
-        "emotion",
         "preact",
         "preact-compat",
-        "preact-emotion",
         "preact-router"
       ]
     },
@@ -25,7 +23,7 @@
   },
   "commands": {
     "install": {
-      "exec": "npm install --silent --save preact preact-compat preact-emotion preact-router emotion@9.2.12 > /dev/null"
+      "exec": "npm install --silent --save preact preact-compat preact-router > /dev/null"
     },
     "install -D": {
       "exec": "npm install --silent -D @babel/cli @babel/core @babel/plugin-proposal-class-properties @babel/plugin-proposal-object-rest-spread @babel/plugin-transform-react-jsx @babel/preset-env @babel/preset-react @babel/preset-typescript @pika/web@0.4.2 @typescript-eslint/eslint-plugin @typescript-eslint/parser babel-plugin-import-pika-web babel-plugin-module-resolver concurrently copyfiles prettier eslint eslint-config-airbnb-typescript eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react serve typescript > /dev/null"

--- a/assets/app-preact/template/src/components/Console/index.tsx
+++ b/assets/app-preact/template/src/components/Console/index.tsx
@@ -1,18 +1,12 @@
 import { h } from 'preact'
-import styled from 'preact-emotion'
 import Typist from '../Typist'
 import text from './text'
 
-const Container = styled('div')`
-  display: flex;
-  width: 750px;
-`
-
 const Console: preact.FunctionalComponent = () => (
   <div>
-    <Container id="console">
+    <div style={{ display: 'flex', width: '750px' }} id="console">
       <Typist file={text} />
-    </Container>
+    </div>
   </div>
 )
 


### PR DESCRIPTION
Removed `preact-emotion` from `app-preact` template due to emotions dropping of support for preact. 

This allows the template `app-preact` to run again, although now it is missing a css-in-js library which I believe is very helpful to have in such a template, I will experiment and try to add another one in the future. 

This solves a part of #19 