### PR TITLE
Merge pull request #28 from dustinsoftware/remove-npx

### DIFF
--- a/assets/app-preact/config.json
+++ b/assets/app-preact/config.json
@@ -5,7 +5,7 @@
     },
     "scripts": {
       "build": "npm run build:ts && npm run build:esm && npm run copy",
-      "build:esm": "npx snowpack --dest dist/web_modules --optimize",
+      "build:esm": "snowpack --dest dist/web_modules --optimize",
       "build:ts": "rm -rf dist && tsc",
       "build:ts:watch": "tsc -w",
       "copy": "copyfiles 'src/*.html' 'src/**/*.gif' 'src/*.css' dist -u 1",
@@ -20,7 +20,7 @@
       "exec": "npm install --silent --save preact > /dev/null"
     },
     "install -D": {
-      "exec": "npm install --silent -D @typescript-eslint/eslint-plugin @typescript-eslint/parser concurrently copyfiles prettier eslint eslint-config-airbnb-typescript eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react serve typescript > /dev/null"
+      "exec": "npm install --silent -D @typescript-eslint/eslint-plugin @typescript-eslint/parser concurrently copyfiles prettier eslint eslint-config-airbnb-typescript eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-prettier eslint-plugin-react serve snowpack typescript > /dev/null"
     }
   }
 }

--- a/assets/app-vue/config.json
+++ b/assets/app-vue/config.json
@@ -7,7 +7,7 @@
       ]
     },
     "scripts": {
-      "prepare": "npx snowpack --clean",
+      "prepare": "snowpack --clean",
       "start": "serve ./"
     }
   },


### PR DESCRIPTION
The `lit` and `typescript` generators already do this. Avoiding `npx` shaves a few seconds off of every build, and pins generated projects to a specific snowpack version via the generated lockfile (which will avoid possibly surprising behavior when snowpack is updated upstream!)