### PR TITLE
fix: JSON formatting

### DIFF
--- a/assets/app-typescript/config.json
+++ b/assets/app-typescript/config.json
@@ -31,7 +31,7 @@
       "clean:build": "rimraf build",
       "browsersync": "browser-sync start -s \"build\" -f \"build\"",
       "commit": "git-cz"
-    },
+    }
   },
   "commands": {
     "install": {


### PR DESCRIPTION
Couldn't build `app-typescript` with this extra comma in `config.json`