### PR TITLE
Allow subfolders in web_modules

### DIFF
--- a/assets/app-typescript/config.json
+++ b/assets/app-typescript/config.json
@@ -24,7 +24,7 @@
       "copy:assets": "cpx \"public/*\"  build",
       "copy:assets:watch": "cpx \"public/*\"  build -w",
       "copy:modules": "cpx \"web_modules/*.js\" \"build/web_modules\"",
-      "copy:modules:watch": "snowpack --include \"src/**/*.ts\" --clean && cpx \"web_modules/*.js\" \"build/web_modules\" -w",
+      "copy:modules:watch": "snowpack --include \"src/**/*.ts\" --clean && cpx \"web_modules/**/*.js\" \"build/web_modules\" -w",
       "minify:js": "node minify.js js",
       "minify:html": "node minify.js html",
       "minify:all": "node minify.js js html",


### PR DESCRIPTION
I tried using this quickstart to prototype some ThreeJS, and unfortunately my enthusiasm was severely deflated by having to figure out this random bug with the package.json.

ThreeJS uses subfolders for it's "extras", which are not copied to build/web_modules without this:
<img width="229" alt="04-25-2020-03 32 27" src="https://user-images.githubusercontent.com/3252307/80275246-aa1d6380-86a5-11ea-812b-91e186db8506.png">
